### PR TITLE
Fixed InvalidArgumentException in TokenRepository::getClaims()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.0.3 under development
 
-- Fix: Added exception handling in TokenRepository::getClaims() with invalid token string (strorch)
+- Fix #43: Added exception handling in TokenRepository::getClaims() with invalid token string (strorch)
 
 
 ## 1.0.2 April 13, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.0.3 under development
 
-- no changes in this release.
+- Fix: Added exception handling in TokenRepository::getClaims() with invalid token string (strorch)
 
 
 ## 1.0.2 April 13, 2021

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -50,7 +50,12 @@ final class TokenRepository implements TokenRepositoryInterface
 
     public function getClaims(string $token, ?string &$format = null): ?array
     {
-        $jws = $this->serializerManager->unserialize($token, $format);
+        try {
+            $jws = $this->serializerManager->unserialize($token, $format);
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+
         $jwk = $this->keyFactory->create();
 
         foreach ($this->algorithmManager->list() as $index => $algorithm) {

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -58,7 +58,7 @@ final class TokenRepository implements TokenRepositoryInterface
 
         $jwk = $this->keyFactory->create();
 
-        foreach ($this->algorithmManager->list() as $index => $algorithm) {
+        foreach ($this->algorithmManager->list() as $index => $_algorithm) {
             /** @var int $index */
             if ($this->verifyToken($jws, $jwk, $index)) {
                 /** @var array<array-key, mixed>|null */

--- a/tests/TokenRepositoryTest.php
+++ b/tests/TokenRepositoryTest.php
@@ -29,6 +29,12 @@ class TokenRepositoryTest extends TestCase
         $this->assertEquals($claims['sub'], $payload['sub']);
     }
 
+    public function testInvalidClaims(): void
+    {
+        $claims = $this->tokenRepository->getClaims('invalid.test.string');
+        $this->assertSame(null, $claims);
+    }
+
     public function testEmptyPayload(): void
     {
         $payload = [];


### PR DESCRIPTION
JWSSerializerManager which is used in TokenRepository throws invalid argument exception and it is not handled by Authentication::$failureHandler class.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | none
