### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      github-actions:
-        patterns:
-          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
 
@@ -18,11 +14,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+        interval: "daily"
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7
-    groups:
-      composer-dependencies:
-        patterns:
-          - "*"
-    versioning-strategy: increase-if-necessary

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -10,6 +10,7 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
+      composer-require-options: '--with-all-dependencies --ignore-platform-req=php --no-progress --ansi'
       os: >-
         ['ubuntu-latest']
       php: >-

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -3,6 +3,9 @@ on:
   - push
 
 name: backwards compatibility
+
+permissions:
+  contents: read
 jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -13,4 +13,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.4']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ on:
 
 name: build
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     uses: yiisoft/actions/.github/workflows/phpunit.yml@master

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -23,6 +23,9 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
+
 jobs:
   composer-require-checker:
     uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -19,6 +19,9 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
     uses: yiisoft/actions/.github/workflows/roave-infection.yml@master

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'config/**'
       - 'src/**'
@@ -21,8 +21,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,9 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
     uses: yiisoft/actions/.github/workflows/psalm.yml@master

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+permissions:
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
+
+jobs:
+  zizmor:
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master


### PR DESCRIPTION
## Summary
- Pin reusable yiisoft/actions workflows to a commit SHA.
- Replace the Rector workflow pull_request_target trigger with pull_request.
- Set read-only GITHUB_TOKEN permissions for read-only workflows.

## Validation
- zizmor --no-progress --no-exit-codes auth-jwt/.github/workflows